### PR TITLE
Fix building error "No such module 'JDAnimationKit'" in Tests.swift file

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -1,6 +1,5 @@
 import UIKit
 import XCTest
-import JDAnimationKit
 
 class Tests: XCTestCase {
     


### PR DESCRIPTION
This import statement is not necessary and moreover it causes building error.
